### PR TITLE
Bugfix/integration time

### DIFF
--- a/src/SparkFun_AS7265X.cpp
+++ b/src/SparkFun_AS7265X.cpp
@@ -379,7 +379,7 @@ void AS7265X::setGain(uint8_t gain)
 //Time will be 2.8ms * [integration cycles + 1]
 void AS7265X::setIntegrationCycles(uint8_t cycleValue)
 {
-  maxWaitTime = (int)(cycleValue * 2.8 * 1.5); //Wait for integration time + 50%
+  maxWaitTime = (int)(cycleValue * 2.8 * 1.5) + 1; //Wait for integration time + 50%
   virtualWriteRegister(AS7265X_INTERGRATION_TIME, cycleValue); //Write
 }
 

--- a/src/SparkFun_AS7265X.h
+++ b/src/SparkFun_AS7265X.h
@@ -202,7 +202,7 @@ private:
 
   uint8_t readRegister(uint8_t addr);
   boolean writeRegister(uint8_t addr, uint8_t val);
-  uint16_t maxWaitTime = 0; //Based on integration cycles
+  uint16_t maxWaitTime = 255; //Based on integration cycles
 };
 
 #endif

--- a/src/SparkFun_AS7265X.h
+++ b/src/SparkFun_AS7265X.h
@@ -202,7 +202,11 @@ private:
 
   uint8_t readRegister(uint8_t addr);
   boolean writeRegister(uint8_t addr, uint8_t val);
-  uint16_t maxWaitTime = 255; //Based on integration cycles
+
+  //Integration time is 2.8 * integration cycles.
+  //We will wait for integration time + 50%
+  //Since maximum number of integration cycles is 255, absolute max wait time is 2.8 * 255 * 1.5 = 1071
+  uint16_t maxWaitTime = 1071;
 };
 
 #endif


### PR DESCRIPTION
This addresses issue #20. maxWaitTime was being used with its default value of 0 in the virtualReadRegister() call in begin() leading to a timeout that would sporadically cause begin() to fail. 

This PR makes the default maxWaitTime its maximum value of 1071 (255 * 2.8 * 1.5). Also makes maxWaitTime round up when being set (otherwise examples 3 and 5 when operating at maximum rate were going very slowly).